### PR TITLE
Fully supporting builds running over gen2 machines

### DIFF
--- a/bitrise_reports/bitrise.py
+++ b/bitrise_reports/bitrise.py
@@ -118,13 +118,16 @@ class RawDataConverter(object):
         return BitriseWorkflow(triggered_workflow)
 
     def minutes_from(self, triggered_at, started_at, finished_at):
-        triggered = datetime.fromisoformat(triggered_at.replace("Z", ""))
-        started = datetime.fromisoformat(triggered_at.replace("Z", ""))
-        finished = datetime.fromisoformat(finished_at.replace("Z", ""))
+        triggered = self.__dt(triggered_at)
+        started = self.__dt(started_at) if started_at is not None else triggered
+        finished = self.__dt(finished_at)
         queued = self.__aproximate_minutes(started - triggered)
         building = self.__aproximate_minutes(finished - started)
         total = self.__aproximate_minutes(finished - triggered)
         return BuildMinutes(queued, building, total)
+
+    def __dt(self, timestamp):
+        return datetime.fromisoformat(timestamp.replace("Z", ""))
 
     def __aproximate_minutes(self, diff):
         return ceil((diff.days * 24 * 60) + (diff.seconds / 60))

--- a/bitrise_reports/metrics.py
+++ b/bitrise_reports/metrics.py
@@ -11,15 +11,17 @@ from .models import (
 from itertools import groupby
 
 LINUX_CREDITS_MULTIPLIER = {
-    MachineSize.small: 1,
-    MachineSize.medium: 2,
-    MachineSize.large: 4,
+    MachineSize.g1small: 1,
+    MachineSize.g1medium: 2,
+    MachineSize.g1large: 4,
 }
 
 OSX_CREDITS_MULTIPLIER = {
-    MachineSize.small: 2,
-    MachineSize.medium: 4,
-    MachineSize.large: 6,
+    MachineSize.g1small: 2,
+    MachineSize.g1medium: 4,
+    MachineSize.g2small: 2,
+    MachineSize.g2medium: 4,
+    MachineSize.g2large: 6,
 }
 
 

--- a/bitrise_reports/models.py
+++ b/bitrise_reports/models.py
@@ -7,9 +7,12 @@ from datetime import datetime
 
 
 class MachineSize(Enum):
-    small = "standard"
-    medium = "elite"
-    large = "elite-xl"
+    g1small = "standard"
+    g1medium = "elite"
+    g1large = "elite-xl"
+    g2small = "g2.4core"
+    g2medium = "g2.8core"
+    g2large = "g2.12core"
 
 
 class BuildStack(Enum):

--- a/tests/test_bitrise.py
+++ b/tests/test_bitrise.py
@@ -52,7 +52,7 @@ def test_retrive_builds_for_project():
     builds = bitrise.builds_for_project(project)
 
     # Then
-    linux = BuildMachine("linux.elite", MachineSize.medium, BuildStack.linux)
+    linux = BuildMachine("linux.elite", MachineSize.g1medium, BuildStack.linux)
     workflow = BitriseWorkflow("pull-request")
 
     expected = [

--- a/tests/test_builds_analyser.py
+++ b/tests/test_builds_analyser.py
@@ -32,7 +32,7 @@ def test_builds_analysed_with_success():
 
     # Given
     project = BitriseProject("android-flagship", "a2b473cfa869c525")
-    machine = BuildMachine("linux.large", MachineSize.large, BuildStack.linux)
+    machine = BuildMachine("linux.elite-xl", MachineSize.g1large, BuildStack.linux)
     workflow = BitriseWorkflow("pull-request")
     builds = [
         BitriseBuild(project, machine, workflow, BuildMinutes(0, 0, 10)),

--- a/tests/test_data_converter.py
+++ b/tests/test_data_converter.py
@@ -19,21 +19,21 @@ import pytest
             "elite",
             "osx-xcode-12.0.x",
             "macos.elite",
-            MachineSize.medium,
+            MachineSize.g1medium,
             BuildStack.osx,
         ),
         (
             "elite-xl",
             "android-docker-linux",
             "linux.elite-xl",
-            MachineSize.large,
+            MachineSize.g1large,
             BuildStack.linux,
         ),
         (
             "standard",
             "android-docker-linux",
             "linux.standard",
-            MachineSize.small,
+            MachineSize.g1small,
             BuildStack.linux,
         ),
     ],
@@ -67,7 +67,7 @@ def test_convert_minutes():
 
     converted = converter.minutes_from(triggered_at, started_at, finished_at)
 
-    queued = 0
+    queued = 1
     building = 11
     total = 11
     assert converted == BuildMinutes(queued, building, total)

--- a/tests/test_json_reporter.py
+++ b/tests/test_json_reporter.py
@@ -66,8 +66,8 @@ def test_project_report(json_reporter):
 def test_report_per_machine(json_reporter):
 
     # Given
-    linux = BuildMachine("linux.large", MachineSize.medium, BuildStack.linux)
-    mac = BuildMachine("mac.elite", MachineSize.large, BuildStack.linux)
+    linux = BuildMachine("linux.g1large", MachineSize.g1medium, BuildStack.linux)
+    mac = BuildMachine("mac.g1medium", MachineSize.g1large, BuildStack.linux)
     android_numbers = CrunchedNumbers(count=10, queued=0, building=30, total=30, credits=120)
     ios_numbers = CrunchedNumbers(count=5, queued=0, building=40, total=40, credits=160)
 
@@ -86,14 +86,14 @@ def test_report_per_machine(json_reporter):
             "description": "Per Machine",
             "details": [
                 {
-                    "name": "linux.large",
+                    "name": "linux.g1large",
                     "count": 10,
                     "queued": 0,
                     "building": 30,
                     "total": 30,
                 },
                 {
-                    "name": "mac.elite",
+                    "name": "mac.g1medium",
                     "count": 5,
                     "queued": 0,
                     "building": 40,

--- a/tests/test_metrics_cruncher.py
+++ b/tests/test_metrics_cruncher.py
@@ -17,9 +17,9 @@ import pytest
 ANDROID = BitriseProject("android-flagship", "adb55be2718fc923")
 IOS = BitriseProject("ios-flagship", "fe9dd48ffd73cd3d")
 
-LINUX_MEDIUM = BuildMachine("linux.elite", MachineSize.medium, BuildStack.linux)
-LINUX_LARGE = BuildMachine("linux.large", MachineSize.large, BuildStack.linux)
-OSX_MEDIUM = BuildMachine("macos.medium", MachineSize.medium, BuildStack.osx)
+LINUX_MEDIUM = BuildMachine("linux.elite", MachineSize.g1medium, BuildStack.linux)
+LINUX_LARGE = BuildMachine("linux.large", MachineSize.g1large, BuildStack.linux)
+OSX_MEDIUM = BuildMachine("macos.medium", MachineSize.g1medium, BuildStack.osx)
 
 PR_WORKFLOW = BitriseWorkflow("pull-request")
 PARALLEL_WORKFLOW = BitriseWorkflow("pull-request-parallel")


### PR DESCRIPTION
## Description
Adds all the nicknames for gen2 machines, so the application won't crash when processing builds running over the new shiny Velocity infrastructure

## Types of changes

- [ ] House cleaning (change at project level, like tooling revamp, refactors, etc)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (something that would cause existing functionality to not work as expected)
- [ ] Documentation (self-explained)
